### PR TITLE
Add DB migration script and remove inline ensureTable logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 APP_ENV=dev
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
+
+# Set to "true" to run DB migrations during `bun run build`.
+# After the migration completes, unset this (or set to "false") so it doesn't
+# re-run on every subsequent deploy.
+RUN_MIGRATIONS=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ bun run preview    # Preview production build
 
 **SEO** — `src/hooks/useSEO.js` exports `useSEO(title, description)` (sets `document.title` and meta description) and `stripHtml(html)` (produces a plain-text excerpt ≤160 chars). Call `useSEO` at the top of every page component.
 
+**Registration system** — `/register/:eventId` is a form page backed by a Netlify serverless function at `netlify/functions/register.mjs`. Event configs (title, sessions, SEO) live in `src/config/registrationEvents.js` — add a new entry there to enable registration for a new event. The function uses `@libsql/client`: locally it reads `APP_ENV=dev` and writes to `./local.db` (SQLite); in production it connects to Turso via `TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` env vars. Duplicate detection is done by normalising names (lowercase, strip diacritics, collapse spaces).
+
+**Database migrations** — schema changes live in `scripts/migrate-db.mjs` as an ordered `MIGRATIONS` array. Applied versions are tracked in a `schema_migrations` table so each migration only runs once. `bun run migrate` runs the script; `bun run build` calls it automatically. The script is a no-op unless `RUN_MIGRATIONS=true` is set in the environment — set this in Netlify env vars before a deploy that needs schema changes, then unset it afterwards. To add a new migration, append to the `MIGRATIONS` array with a unique `version` string; never edit or reorder existing entries.
+
 ## Git Workflow
 
 - Active development branch is `dev` — always commit and push to `dev`

--- a/README.md
+++ b/README.md
@@ -126,9 +126,29 @@ Copy `.env.example` to `.env` and fill in:
 APP_ENV=dev                  # "dev" → local SQLite, anything else → Turso
 TURSO_DATABASE_URL=          # libsql://... (required in prod)
 TURSO_AUTH_TOKEN=            # JWT token (required in prod)
+RUN_MIGRATIONS=false         # set to "true" only when a deploy needs schema changes
 ```
 
 On Netlify, set `APP_ENV=prod` plus the Turso credentials in the **Site settings → Environment variables** dashboard.
+
+### Database migrations
+
+Schema changes are handled by `scripts/migrate-db.mjs` — a versioned migration runner that tracks applied versions in a `schema_migrations` table, so each migration only ever runs once.
+
+`bun run migrate` runs the script directly. `bun run build` calls it automatically, but it is a **no-op** unless `RUN_MIGRATIONS=true`.
+
+**Workflow for schema changes:**
+
+1. Add a new entry to the `MIGRATIONS` array in `scripts/migrate-db.mjs` with a unique `version` string
+2. Set `RUN_MIGRATIONS=true` in Netlify env vars
+3. Deploy — the migration runs once during the build
+4. Set `RUN_MIGRATIONS=false` (or unset it) so subsequent deploys skip it
+
+To run a migration locally against the local SQLite file:
+
+```bash
+APP_ENV=dev RUN_MIGRATIONS=true bun run migrate
+```
 
 ### Adding a new Eid registration event
 
@@ -154,7 +174,7 @@ Then link to `/register/eid-adha-1447` from the relevant news or event post. No 
 ## Deployment
 
 Netlify — configured in `netlify.toml`:
-- Build command: `bun run build`
+- Build command: `bun run build` (runs `bun run migrate` first, no-op unless `RUN_MIGRATIONS=true`)
 - Publish directory: `dist`
 - SPA redirect: `/* → /index.html`
 - Functions directory: `netlify/functions`

--- a/netlify/functions/register.mjs
+++ b/netlify/functions/register.mjs
@@ -19,31 +19,6 @@ function normalizeName(name) {
     .replace(/\s+/g, " ");
 }
 
-let tableReady = false;
-
-async function ensureTable(client) {
-  if (tableReady) return;
-  await client.execute(`
-    CREATE TABLE IF NOT EXISTS registrations (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      event_id TEXT NOT NULL DEFAULT '',
-      name TEXT NOT NULL,
-      name_normalized TEXT NOT NULL DEFAULT '',
-      session INTEGER NOT NULL,
-      attendees INTEGER NOT NULL DEFAULT 1,
-      created_at TEXT NOT NULL
-    )
-  `);
-  // Migrate existing tables that lack newer columns
-  for (const col of [
-    "ALTER TABLE registrations ADD COLUMN event_id TEXT NOT NULL DEFAULT ''",
-    "ALTER TABLE registrations ADD COLUMN name_normalized TEXT NOT NULL DEFAULT ''",
-  ]) {
-    try { await client.execute(col) } catch { /* already exists */ }
-  }
-  tableReady = true;
-}
-
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -53,12 +28,6 @@ function json(data, status = 200) {
 
 export default async function handler(req, context) {
   const client = getClient();
-
-  try {
-    await ensureTable(client);
-  } catch {
-    return json({ error: "Database error" }, 500);
-  }
 
   if (req.method === "GET") {
     const url = new URL(req.url);

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "build": "bun run migrate && vite build",
+    "preview": "vite preview",
+    "migrate": "bun scripts/migrate-db.mjs"
   },
   "dependencies": {
     "@libsql/client": "^0.17.0",

--- a/scripts/migrate-db.mjs
+++ b/scripts/migrate-db.mjs
@@ -1,0 +1,121 @@
+/**
+ * Database migration script.
+ *
+ * Run manually:   bun run migrate
+ * Auto-run:       set RUN_MIGRATIONS=true in Netlify env vars before deploying.
+ *                 After the migration completes, unset it so it doesn't re-run
+ *                 on every subsequent deploy.
+ *
+ * Local dev:      APP_ENV=dev  → writes to ./local.db (SQLite)
+ * Production:     TURSO_DATABASE_URL + TURSO_AUTH_TOKEN required
+ */
+
+import { createClient } from "@libsql/client";
+
+if (process.env.RUN_MIGRATIONS !== "true") {
+  console.log("RUN_MIGRATIONS is not 'true' — skipping migrations.");
+  process.exit(0);
+}
+
+function getClient() {
+  if (process.env.APP_ENV === "dev") {
+    console.log("Using local SQLite database: ./local.db");
+    return createClient({ url: "file:./local.db" });
+  }
+
+  const url = process.env.TURSO_DATABASE_URL;
+  const authToken = process.env.TURSO_AUTH_TOKEN;
+
+  if (!url || !authToken) {
+    console.error(
+      "ERROR: TURSO_DATABASE_URL and TURSO_AUTH_TOKEN must be set for production migrations."
+    );
+    process.exit(1);
+  }
+
+  console.log(`Using Turso database: ${url}`);
+  return createClient({ url, authToken });
+}
+
+/**
+ * Ordered list of migrations. Each entry has:
+ *   version  — unique identifier; never rename or reorder existing ones
+ *   sql      — DDL to execute (idempotent where possible)
+ */
+const MIGRATIONS = [
+  {
+    version: "001_create_registrations",
+    sql: `
+      CREATE TABLE IF NOT EXISTS registrations (
+        id           INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id     TEXT    NOT NULL DEFAULT '',
+        name         TEXT    NOT NULL,
+        name_normalized TEXT NOT NULL DEFAULT '',
+        session      INTEGER NOT NULL,
+        attendees    INTEGER NOT NULL DEFAULT 1,
+        created_at   TEXT    NOT NULL
+      )
+    `,
+  },
+  {
+    version: "002_create_schema_migrations",
+    sql: `
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version    TEXT NOT NULL PRIMARY KEY,
+        applied_at TEXT NOT NULL
+      )
+    `,
+  },
+  // Add future migrations here — never edit or remove existing ones.
+  //
+  // Example:
+  // {
+  //   version: "003_add_phone_to_registrations",
+  //   sql: "ALTER TABLE registrations ADD COLUMN phone TEXT NOT NULL DEFAULT ''",
+  // },
+];
+
+async function migrate() {
+  const client = getClient();
+
+  // Bootstrap the tracking table so we can record applied versions.
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version    TEXT NOT NULL PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    )
+  `);
+
+  const applied = await client.execute(
+    "SELECT version FROM schema_migrations"
+  );
+  const appliedSet = new Set(applied.rows.map((r) => r.version));
+
+  let ran = 0;
+  for (const migration of MIGRATIONS) {
+    if (appliedSet.has(migration.version)) {
+      console.log(`  ✓ ${migration.version} (already applied)`);
+      continue;
+    }
+
+    console.log(`  → Running ${migration.version} ...`);
+    await client.execute(migration.sql);
+    await client.execute({
+      sql: "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+      args: [migration.version, new Date().toISOString()],
+    });
+    console.log(`  ✓ ${migration.version} applied`);
+    ran++;
+  }
+
+  console.log(
+    ran === 0
+      ? "\nAll migrations already applied — nothing to do."
+      : `\n${ran} migration(s) applied successfully.`
+  );
+}
+
+migrate().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
- Add scripts/migrate-db.mjs: versioned migration runner that tracks applied versions in schema_migrations table; no-op unless RUN_MIGRATIONS=true
- Wire bun run migrate into bun run build so it runs at deploy time
- Remove ensureTable and tableReady flag from register.mjs
- Add RUN_MIGRATIONS to .env.example
- Update CLAUDE.md and README with migration workflow docs